### PR TITLE
Detect git directory instead of assuming git dir is in current directory

### DIFF
--- a/src/GitHooksInstallerPlugin/Composer/Installer.php
+++ b/src/GitHooksInstallerPlugin/Composer/Installer.php
@@ -104,12 +104,17 @@ class Installer extends LibraryInstaller
      */
     protected function getGitHooksPath()
     {
-        return '.git/hooks';
+        $gitDir = exec('git rev-parse --git-dir');
+        if ($gitDir != '.git') {
+            $gitDir .= DIRECTORY_SEPARATOR . '.git';
+        }
+
+        return $gitDir . DIRECTORY_SEPARATOR . 'hooks';
     }
 
     protected function getHooksInstallationPath()
     {
-        return '.git/hooks/.GitHooksInstallerPlugin';
+        return $this->getGitHooksPath() . DIRECTORY_SEPARATOR . '.GitHooksInstallerPlugin';
     }
 
     /**


### PR DESCRIPTION
fixes #1  by detecting the git directory instead of having it hardcoded in the code